### PR TITLE
Using Informers instead of REST API

### DIFF
--- a/examples/goflow-kube.yaml
+++ b/examples/goflow-kube.yaml
@@ -79,3 +79,4 @@ rules:
   verbs:
   - list
   - get
+  - watch

--- a/src/go.sum
+++ b/src/go.sum
@@ -74,6 +74,7 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -113,6 +114,7 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -120,9 +122,11 @@ github.com/googleapis/gnostic v0.4.1 h1:DLJCy1n/vrD4HPjOvYcT8aYQXpPIzoRZONaYwyyc
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=

--- a/src/kube-enricher.go
+++ b/src/kube-enricher.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"bufio"
-	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 	"strings"
+
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/jotak/goflow2-kube-enricher/meta"
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -20,6 +23,7 @@ var (
 	version       = "unknown"
 	app           = "kube-enricher"
 	fieldsMapping = flag.String("mapping", "SrcAddr=Src,DstAddr=Dst", "Mapping of fields containing IPs to prefixes for new fields")
+	kubeconfig    = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	logLevel      = flag.String("loglevel", "info", "Log level")
 	versionFlag   = flag.Bool("v", false, "Print version")
 	log           = logrus.WithField("module", app)
@@ -50,21 +54,17 @@ func main() {
 		log.Fatal(err)
 	}
 
-	config, err := rest.InClusterConfig()
+	clientset, err := kubernetes.NewForConfig(loadConfig())
 	if err != nil {
 		log.Fatal(err)
 	}
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		log.Fatal(err)
-	}
-
+	informers := meta.NewInformers(clientset)
 	log.Infof("Starting %s at log level %s", appVersion, *logLevel)
 
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
 		in := scanner.Bytes()
-		enriched, err := enrich(clientset, in, mapping)
+		enriched, err := enrich(informers, in, mapping)
 		if err != nil {
 			log.Error(err)
 			fmt.Println(string(in))
@@ -78,13 +78,41 @@ func main() {
 	}
 }
 
+// loadConfig fetches a given kubernetes configuration in the following order
+// 1. path provided by the -kubeconfig CLI argument
+// 2. path provided by the KUBECONFIG environment variable
+// 3. REST InClusterConfig
+func loadConfig() *rest.Config {
+	var config *rest.Config
+	var err error
+	if kubeconfig != nil && *kubeconfig != "" {
+		config, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
+		if err != nil {
+			log.WithError(err).WithField("kubeconfig", *kubeconfig).
+				Fatal("can't find provided kubeconfig param path")
+		}
+	} else if kfgPath := os.Getenv("KUBECONFIG"); kfgPath != "" {
+		config, err = clientcmd.BuildConfigFromFlags("", kfgPath)
+		if err != nil {
+			log.WithError(err).WithField("kubeconfig", kfgPath).
+				Fatal("can't find provided KUBECONFIG env path")
+		}
+	} else {
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			log.WithError(err).Fatal("can't load in-cluster REST config")
+		}
+	}
+	return config
+}
+
 type fieldMapping struct {
 	fieldName string
 	prefixOut string
 }
 
 func parseFieldMapping(in string) ([]fieldMapping, error) {
-	mapping := []fieldMapping{}
+	var mapping []fieldMapping
 	fields := strings.Split(in, ",")
 	for _, pair := range fields {
 		kv := strings.Split(pair, "=")
@@ -112,7 +140,7 @@ var svcNameFunc = func(services interface{}, idx int) string {
 	return svc.Name + "." + svc.Namespace
 }
 
-func enrich(clientset *kubernetes.Clientset, rawRecord []byte, mapping []fieldMapping) ([]byte, error) {
+func enrich(informers meta.Informers, rawRecord []byte, mapping []fieldMapping) ([]byte, error) {
 	// TODO: allow protobuf input
 	var record map[string]interface{}
 	err := json.Unmarshal(rawRecord, &record)
@@ -120,74 +148,72 @@ func enrich(clientset *kubernetes.Clientset, rawRecord []byte, mapping []fieldMa
 		return nil, err
 	}
 
-	// TODO: use cache
 	for _, fieldMap := range mapping {
-		addWarnings := []string{}
-
-		if val, ok := record[fieldMap.fieldName]; ok {
-			if ip, ok := val.(string); ok {
-				pods, err := clientset.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{FieldSelector: "status.podIP=" + ip})
-				if err != nil {
-					log.Warnf("Failed to get pod [ip=%s,err=%v]", ip, err)
-				} else if len(pods.Items) > 0 {
-					addWarnings = checkTooMany(addWarnings, "pods", "same IP", pods.Items, len(pods.Items), podNameFunc)
-					pod := pods.Items[0]
-					record[fieldMap.prefixOut+"Pod"] = pod.Name
-					record[fieldMap.prefixOut+"Namespace"] = pod.Namespace
-					record[fieldMap.prefixOut+"HostIP"] = pod.Status.HostIP
-					if len(pod.OwnerReferences) > 0 {
-						addWarnings = checkTooMany(addWarnings, "owners", "pod "+pod.Name, pod.OwnerReferences, len(pod.OwnerReferences), ownerNameFunc)
-						ref := pod.OwnerReferences[0]
-						if ref.Kind == "ReplicaSet" {
-							// Search deeper (e.g. Deployment, DeploymentConfig)
-							rs, err := clientset.AppsV1().ReplicaSets(pod.Namespace).Get(context.TODO(), ref.Name, metav1.GetOptions{})
-							if err != nil {
-								log.Warnf("Failed to get replicaset [ns=%s,name=%s,err=%v]", pod.Namespace, ref.Name, err)
-							} else if len(rs.OwnerReferences) > 0 {
-								addWarnings = checkTooMany(addWarnings, "owners", "replica "+rs.Name, rs.OwnerReferences, len(rs.OwnerReferences), ownerNameFunc)
-								ref = rs.OwnerReferences[0]
-							}
-						}
-						record[fieldMap.prefixOut+"Workload"] = ref.Name
-						record[fieldMap.prefixOut+"WorkloadKind"] = ref.Kind
-					} else {
-						// Consider a pod without owner as self-owned
-						record[fieldMap.prefixOut+"Workload"] = pod.Name
-						record[fieldMap.prefixOut+"WorkloadKind"] = "Pod"
-					}
-				} else {
-					// Try service
-					services, err := findServicesByIP(clientset, ip)
-					if err != nil {
-						log.Warnf("Failed to get services [err=%v]", err)
-					} else if len(services) > 0 {
-						addWarnings = checkTooMany(addWarnings, "services", "same IP", services, len(services), svcNameFunc)
-						svc := services[0]
-						record[fieldMap.prefixOut+"Workload"] = svc.Name
-						record[fieldMap.prefixOut+"WorkloadKind"] = "Service"
-						record[fieldMap.prefixOut+"Namespace"] = svc.Namespace
-					} else {
-						log.Tracef("No pods or services found for IP %s", ip)
-					}
-				}
-			} else {
-				log.Warnf("String expected for field %s value %v", fieldMap.fieldName, val)
-			}
-		} else {
+		val, ok := record[fieldMap.fieldName]
+		if !ok {
 			log.Infof("Field %s not found in record", fieldMap.fieldName)
+			continue
 		}
-
-		if len(addWarnings) > 0 {
-			record[fieldMap.prefixOut+"Warn"] = strings.Join(addWarnings, "; ")
+		ip, ok := val.(string)
+		if !ok {
+			log.Warnf("String expected for field %s value %v", fieldMap.fieldName, val)
+			continue
+		}
+		if pod, ok := informers.PodByIP(ip); ok {
+			enrichPod(informers, record, fieldMap, pod)
+		} else {
+			// If there is no Pod for such IP, we try searching for a service
+			enrichService(informers, ip, record, fieldMap)
 		}
 	}
 
 	return json.Marshal(record)
 }
 
+func enrichService(informers meta.Informers, ip string, record map[string]interface{}, fieldMap fieldMapping) {
+	svc, ok := informers.ServiceByIP(ip)
+	if !ok {
+		log.Warnf("Failed to get Service [ip=%v]", ip)
+	} else {
+		record[fieldMap.prefixOut+"Workload"] = svc.Name
+		record[fieldMap.prefixOut+"WorkloadKind"] = "Service"
+		record[fieldMap.prefixOut+"Namespace"] = svc.Namespace
+	}
+}
+
+func enrichPod(informers meta.Informers, record map[string]interface{}, fieldMap fieldMapping, pod *v1.Pod) {
+	var warnings []string
+	record[fieldMap.prefixOut+"Pod"] = pod.Name
+	record[fieldMap.prefixOut+"Namespace"] = pod.Namespace
+	record[fieldMap.prefixOut+"HostIP"] = pod.Status.HostIP
+	if len(pod.OwnerReferences) > 0 {
+		warnings = checkTooMany(warnings, "owners", "pod "+pod.Name, pod.OwnerReferences, len(pod.OwnerReferences), ownerNameFunc)
+		ref := pod.OwnerReferences[0]
+		if ref.Kind == "ReplicaSet" {
+			// Search deeper (e.g. Deployment, DeploymentConfig)
+			rs, ok := informers.ReplicaSet(pod.Namespace, ref.Name)
+			if !ok {
+				log.Warnf("Failed to get ReplicaSet [ns=%s,name=%s]", pod.Namespace, ref.Name)
+			} else if len(rs.OwnerReferences) > 0 {
+				warnings = checkTooMany(warnings, "owners", "replica "+rs.Name, rs.OwnerReferences, len(rs.OwnerReferences), ownerNameFunc)
+				ref = rs.OwnerReferences[0]
+			}
+		}
+		record[fieldMap.prefixOut+"Workload"] = ref.Name
+		record[fieldMap.prefixOut+"WorkloadKind"] = ref.Kind
+	} else {
+		// Consider a pod without owner as self-owned
+		record[fieldMap.prefixOut+"Workload"] = pod.Name
+		record[fieldMap.prefixOut+"WorkloadKind"] = "Pod"
+	}
+	if len(warnings) > 0 {
+		record[fieldMap.prefixOut+"Warn"] = strings.Join(warnings, "; ")
+	}
+}
+
 func checkTooMany(warnings []string, kind, ref string, items interface{}, size int, nameFunc func(interface{}, int) string) []string {
 	if size > 1 {
-		names := []string{}
+		var names []string
 		for i := 0; i < size; i++ {
 			names = append(names, nameFunc(items, i))
 		}
@@ -196,18 +222,4 @@ func checkTooMany(warnings []string, kind, ref string, items interface{}, size i
 		warnings = append(warnings, warn)
 	}
 	return warnings
-}
-
-func findServicesByIP(clientset *kubernetes.Clientset, ip string) ([]v1.Service, error) {
-	services, err := clientset.CoreV1().Services("").List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return []v1.Service{}, err
-	}
-	filtered := []v1.Service{}
-	for _, svc := range services.Items {
-		if svc.Spec.ClusterIP == ip {
-			filtered = append(filtered, svc)
-		}
-	}
-	return filtered, nil
 }


### PR DESCRIPTION
Also:

- Optionally loading configuration from `KUBECONFIG` env or `kubeconfig` CLI
- Few structures have been modified to avoid too much nesting.
- Removed warnings for multiple Pods or Services matching the same IP, given that this is not possible in Kubernetes (excepting Host networked pods, which are ignored)
